### PR TITLE
Render HTML description preview

### DIFF
--- a/lib/modules/media/media_info_view.dart
+++ b/lib/modules/media/media_info_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:otraku/common/utils/consts.dart';
+import 'package:otraku/common/widgets/html_content.dart';
 import 'package:otraku/common/widgets/shadowed_overflow_list.dart';
 import 'package:otraku/modules/discover/discover_models.dart';
 import 'package:otraku/modules/discover/discover_providers.dart';
@@ -20,6 +21,22 @@ class MediaInfoView extends StatelessWidget {
 
   final Media media;
   final ScrollController scrollCtrl;
+
+  Widget _buildFadingHtmlDescription(String description) {
+    return ShaderMask(
+      // Recreate the TextOverflow.fade effect
+      shaderCallback: (bounds) => const LinearGradient(
+        begin: Alignment(0.0, 0.8),
+        end: Alignment(0.0, 1.0),
+        colors: [Colors.white, Colors.transparent],
+      ).createShader(bounds),
+      child: ConstrainedBox(
+        // Limit height to 4 lines of Text
+        constraints: const BoxConstraints(maxHeight: 72),
+        child: HtmlContent(description),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -78,11 +95,7 @@ class MediaInfoView extends StatelessWidget {
                   child: Card(
                     child: Padding(
                       padding: Consts.padding,
-                      child: Text(
-                        info.description,
-                        maxLines: 4,
-                        overflow: TextOverflow.fade,
-                      ),
+                      child: _buildFadingHtmlDescription(info.description),
                     ),
                   ),
                   onTap: () => showPopUp(

--- a/lib/modules/media/media_info_view.dart
+++ b/lib/modules/media/media_info_view.dart
@@ -22,22 +22,6 @@ class MediaInfoView extends StatelessWidget {
   final Media media;
   final ScrollController scrollCtrl;
 
-  Widget _buildFadingHtmlDescription(String description) {
-    return ShaderMask(
-      // Recreate the TextOverflow.fade effect
-      shaderCallback: (bounds) => const LinearGradient(
-        begin: Alignment(0.0, 0.8),
-        end: Alignment(0.0, 1.0),
-        colors: [Colors.white, Colors.transparent],
-      ).createShader(bounds),
-      child: ConstrainedBox(
-        // Limit height to 4 lines of Text
-        constraints: const BoxConstraints(maxHeight: 72),
-        child: HtmlContent(description),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final info = media.info;
@@ -95,7 +79,17 @@ class MediaInfoView extends StatelessWidget {
                   child: Card(
                     child: Padding(
                       padding: Consts.padding,
-                      child: _buildFadingHtmlDescription(info.description),
+                      child: ShaderMask(
+                        shaderCallback: (bounds) => const LinearGradient(
+                          begin: Alignment(0.0, 0.7),
+                          end: Alignment(0.0, 1.0),
+                          colors: [Colors.white, Colors.transparent],
+                        ).createShader(bounds),
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxHeight: 72),
+                          child: HtmlContent(info.description),
+                        ),
+                      ),
                     ),
                   ),
                   onTap: () => showPopUp(


### PR DESCRIPTION
Reuse HtmlContent to render out the HTML of the description in the preview window.
Fixes #108

Tested on phone and 10" tablet.

Used a ConstrainedBox to limit the height to 72, the same as a Text widget with 4 lines.
Used a ShaderMask to recreate the TextOverflow.fade. It looks almost identical, see pictures below

#### Old: 4 line text with TextOverflow.fade
![old-text-4-lines](https://github.com/lotusprey/otraku/assets/1096841/a84f7de7-5cf5-4479-9e9e-2f47cfc61505)
#### New: ShaderMask and ConstrainedBox 72
![new-shader-mask](https://github.com/lotusprey/otraku/assets/1096841/e78db112-b65e-484e-884a-88668ce75388)


