### PR TITLE
Make all usernames copyable

### DIFF
--- a/lib/common/widgets/link_tile.dart
+++ b/lib/common/widgets/link_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:otraku/common/utils/routing.dart';
 import 'package:otraku/modules/discover/discover_models.dart';
@@ -11,12 +12,14 @@ class LinkTile extends StatelessWidget {
     required this.info,
     required this.discoverType,
     required this.child,
+    this.additionalData,
     super.key,
   });
 
   final DiscoverType discoverType;
   final int id;
   final String? info;
+  final String? additionalData;
   final Widget child;
 
   @override
@@ -31,10 +34,13 @@ class LinkTile extends StatelessWidget {
         DiscoverType.User => Routes.user(id, info),
         DiscoverType.Review => Routes.review(id, info),
       }),
-      onLongPress: () {
-        if (discoverType == DiscoverType.Anime ||
-            discoverType == DiscoverType.Manga) {
-          showSheet(context, EditView((id: id, setComplete: false)));
+      onLongPress: () async {
+        switch (discoverType) {
+          case DiscoverType.Anime || DiscoverType.Manga:
+            showSheet(context, EditView((id: id, setComplete: false)));
+          case DiscoverType.User:
+            await Clipboard.setData(ClipboardData(text: "$additionalData"));
+          default:
         }
       },
       child: child,

--- a/lib/common/widgets/link_tile.dart
+++ b/lib/common/widgets/link_tile.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:otraku/common/utils/routing.dart';
+import 'package:otraku/common/widgets/overlays/toast.dart';
 import 'package:otraku/modules/discover/discover_models.dart';
 import 'package:otraku/modules/edit/edit_view.dart';
 import 'package:otraku/common/widgets/overlays/sheets.dart';
@@ -39,7 +39,7 @@ class LinkTile extends StatelessWidget {
           case DiscoverType.Anime || DiscoverType.Manga:
             showSheet(context, EditView((id: id, setComplete: false)));
           case DiscoverType.User:
-            await Clipboard.setData(ClipboardData(text: "$additionalData"));
+            Toast.copy(context, "$additionalData");
           default:
         }
       },

--- a/lib/modules/activity/activity_card.dart
+++ b/lib/modules/activity/activity_card.dart
@@ -71,6 +71,7 @@ class ActivityCard extends StatelessWidget {
                 id: activity.agent.id,
                 info: activity.agent.imageUrl,
                 discoverType: DiscoverType.User,
+                additionalData: activity.agent.name,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -108,6 +109,7 @@ class ActivityCard extends StatelessWidget {
                 id: activity.reciever!.id,
                 info: activity.reciever!.imageUrl,
                 discoverType: DiscoverType.User,
+                additionalData: activity.reciever?.name,
                 child: ClipRRect(
                   borderRadius: Consts.borderRadiusMin,
                   child: CachedImage(

--- a/lib/modules/activity/activity_view.dart
+++ b/lib/modules/activity/activity_view.dart
@@ -176,6 +176,7 @@ class _TopBarContent extends StatelessWidget {
               id: activity.agent.id,
               info: activity.agent.imageUrl,
               discoverType: DiscoverType.User,
+              additionalData: activity.agent.name,
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -216,6 +217,7 @@ class _TopBarContent extends StatelessWidget {
               id: activity.reciever!.id,
               info: activity.reciever!.imageUrl,
               discoverType: DiscoverType.User,
+              additionalData: activity.agent.name,
               child: ClipRRect(
                 borderRadius: Consts.borderRadiusMin,
                 child: CachedImage(

--- a/lib/modules/activity/reply_card.dart
+++ b/lib/modules/activity/reply_card.dart
@@ -29,6 +29,7 @@ class ReplyCard extends StatelessWidget {
           id: reply.user.id,
           info: reply.user.imageUrl,
           discoverType: DiscoverType.User,
+          additionalData: reply.user.name,
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/lib/modules/media/media_grids.dart
+++ b/lib/modules/media/media_grids.dart
@@ -117,6 +117,7 @@ class MediaReviewGrid extends StatelessWidget {
               id: items[i].userId,
               info: items[i].avatar,
               discoverType: DiscoverType.User,
+              additionalData: items[i].username,
               child: Row(
                 children: [
                   Hero(
@@ -194,6 +195,7 @@ class MediaFollowingGrid extends StatelessWidget {
           id: items[i].userId,
           info: items[i].userAvatar,
           discoverType: DiscoverType.User,
+          additionalData: items[i].userName,
           child: Card(
             child: Row(
               children: [

--- a/lib/modules/user/user_grid.dart
+++ b/lib/modules/user/user_grid.dart
@@ -37,6 +37,7 @@ class _Tile extends StatelessWidget {
       id: item.id,
       info: item.imageUrl,
       discoverType: DiscoverType.User,
+      additionalData: item.name,
       child: Column(
         children: [
           Expanded(


### PR DESCRIPTION
Intended as a potential implementation for #92, but also has the side effect that you can copy usernames directly from the user grid, etc.

I think this implementation kinda sucks because
1) the new `additionalData` field only applies to users and the name is not descriptive enough to clarify this on its own
2) if you add a new `LinkTile` of type `DiscoverType.User` somewhere, it requires you to pass `additionalData`. If you don't, it will copy the string “null” (could be fixed via a simple if condition).

But I wanted to suggest this anyway. 

Alternatives I can come up with are:
1) using a different widget for the long press detection 
2) passing a function or something like that instead of an arbitrary `String? additionalData`, which would be much more powerful (but maybe unnecessary?)