### PR TITLE
Add comment reply button

### DIFF
--- a/lib/modules/activity/activity_view.dart
+++ b/lib/modules/activity/activity_view.dart
@@ -119,7 +119,7 @@ class _ActivityViewState extends ConsumerState<ActivityView> {
                             delegate: SliverChildBuilderDelegate(
                               childCount: data.replies.items.length,
                               (context, i) =>
-                                  ReplyCard(ref, widget.id, data.replies.items[i]),
+                                  ReplyCard(widget.id, data.replies.items[i]),
                             ),
                           ),
                           SliverFooter(loading: data.replies.hasNext),

--- a/lib/modules/activity/activity_view.dart
+++ b/lib/modules/activity/activity_view.dart
@@ -119,7 +119,7 @@ class _ActivityViewState extends ConsumerState<ActivityView> {
                             delegate: SliverChildBuilderDelegate(
                               childCount: data.replies.items.length,
                               (context, i) =>
-                                  ReplyCard(widget.id, data.replies.items[i]),
+                                  ReplyCard(ref, widget.id, data.replies.items[i]),
                             ),
                           ),
                           SliverFooter(loading: data.replies.hasNext),

--- a/lib/modules/activity/reply_card.dart
+++ b/lib/modules/activity/reply_card.dart
@@ -64,26 +64,25 @@ class ReplyCard extends StatelessWidget {
                       style: Theme.of(context).textTheme.labelSmall,
                     ),
                     const Spacer(),
-                    ...[
-                      Consumer(
-                        builder: (context, ref, _) => SizedBox(
-                          height: 40,
-                          child: reply.user.id == Options().id ?
-                          Tooltip(
-                            message: 'More',
-                            child: InkResponse(
-                              radius: 10,
-                              onTap: () => _showMoreSheet(context, ref),
-                              child: const Icon(
-                                Ionicons.ellipsis_horizontal,
-                                size: Consts.iconSmall,
-                              ),
-                            ),
-                          ) : _ReplyMentionButton(ref, activityId, reply.user),
-                        ),
+                    Consumer(
+                      builder: (context, ref, _) => SizedBox(
+                        height: 40,
+                        child: reply.user.id == Options().id
+                            ? Tooltip(
+                                message: 'More',
+                                child: InkResponse(
+                                  radius: 10,
+                                  onTap: () => _showMoreSheet(context, ref),
+                                  child: const Icon(
+                                    Ionicons.ellipsis_horizontal,
+                                    size: Consts.iconSmall,
+                                  ),
+                                ),
+                              )
+                            : _ReplyMentionButton(ref, activityId, reply.user),
                       ),
+                    ),
                       const SizedBox(width: 10),
-                    ],
                     _ReplyLikeButton(reply),
                   ],
                 ),

--- a/lib/modules/activity/reply_card.dart
+++ b/lib/modules/activity/reply_card.dart
@@ -15,8 +15,9 @@ import 'package:otraku/common/widgets/overlays/dialogs.dart';
 import 'package:otraku/common/widgets/overlays/sheets.dart';
 
 class ReplyCard extends StatelessWidget {
-  const ReplyCard(this.activityId, this.reply);
+  const ReplyCard(this.ref, this.activityId, this.reply);
 
+  final WidgetRef ref;
   final int activityId;
   final ActivityReply reply;
 
@@ -83,6 +84,10 @@ class ReplyCard extends StatelessWidget {
                       ),
                       const SizedBox(width: 10),
                     ],
+                    Visibility(
+                        visible: reply.user.id != Options().id,
+                        child: _ReplyMentionButton(ref, activityId, reply.user)
+                    ),
                     _ReplyLikeButton(reply),
                   ],
                 ),
@@ -142,6 +147,50 @@ class ReplyCard extends StatelessWidget {
           ),
         ),
       ]),
+    );
+  }
+}
+
+class _ReplyMentionButton extends StatefulWidget {
+  const _ReplyMentionButton(this.ref, this.activityId, this.user);
+
+  final WidgetRef ref;
+  final int activityId;
+  final ActivityUser user;
+
+  @override
+  State<StatefulWidget> createState() => _ReplyMentionButtonState();
+}
+
+class _ReplyMentionButtonState extends State<_ReplyMentionButton> {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 40,
+      child: Row(
+        children: [
+          Tooltip(
+            message: 'Reply',
+            child: InkResponse(
+              radius: 10,
+              onTap: () => showSheet(
+                context,
+                CompositionView(
+                  composition: Composition.reply(null, '@${widget.user.name} ', widget.activityId),
+                  onDone: (map) => widget.ref
+                      .read(activityProvider(widget.activityId).notifier)
+                      .appendReply(map),
+                ),
+              ),
+              child: const Icon(
+                Icons.reply,
+                size: Consts.iconSmall,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+        ],
+      ),
     );
   }
 }

--- a/lib/modules/activity/reply_card.dart
+++ b/lib/modules/activity/reply_card.dart
@@ -15,9 +15,8 @@ import 'package:otraku/common/widgets/overlays/dialogs.dart';
 import 'package:otraku/common/widgets/overlays/sheets.dart';
 
 class ReplyCard extends StatelessWidget {
-  const ReplyCard(this.ref, this.activityId, this.reply);
+  const ReplyCard(this.activityId, this.reply);
 
-  final WidgetRef ref;
   final int activityId;
   final ActivityReply reply;
 
@@ -65,11 +64,12 @@ class ReplyCard extends StatelessWidget {
                       style: Theme.of(context).textTheme.labelSmall,
                     ),
                     const Spacer(),
-                    if (reply.user.id == Options().id) ...[
+                    ...[
                       Consumer(
                         builder: (context, ref, _) => SizedBox(
                           height: 40,
-                          child: Tooltip(
+                          child: reply.user.id == Options().id ?
+                          Tooltip(
                             message: 'More',
                             child: InkResponse(
                               radius: 10,
@@ -79,20 +79,11 @@ class ReplyCard extends StatelessWidget {
                                 size: Consts.iconSmall,
                               ),
                             ),
-                          ),
+                          ) : _ReplyMentionButton(ref, activityId, reply.user),
                         ),
                       ),
                       const SizedBox(width: 10),
                     ],
-                    Visibility(
-                        visible: reply.user.id != Options().id,
-                        child: Row(
-                          children: [
-                            _ReplyMentionButton(ref, activityId, reply.user),
-                            const SizedBox(width: 10),
-                          ],
-                        )
-                    ),
                     _ReplyLikeButton(reply),
                   ],
                 ),

--- a/lib/modules/activity/reply_card.dart
+++ b/lib/modules/activity/reply_card.dart
@@ -156,18 +156,13 @@ class ReplyCard extends StatelessWidget {
   }
 }
 
-class _ReplyMentionButton extends StatefulWidget {
+class _ReplyMentionButton extends StatelessWidget {
   const _ReplyMentionButton(this.ref, this.activityId, this.user);
 
   final WidgetRef ref;
   final int activityId;
   final ActivityUser user;
 
-  @override
-  State<StatefulWidget> createState() => _ReplyMentionButtonState();
-}
-
-class _ReplyMentionButtonState extends State<_ReplyMentionButton> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
@@ -179,9 +174,9 @@ class _ReplyMentionButtonState extends State<_ReplyMentionButton> {
           onTap: () => showSheet(
             context,
             CompositionView(
-              composition: Composition.reply(null, '@${widget.user.name} ', widget.activityId),
-              onDone: (map) => widget.ref
-                  .read(activityProvider(widget.activityId).notifier)
+              composition: Composition.reply(null, '@${user.name} ', activityId),
+              onDone: (map) => ref
+                  .read(activityProvider(activityId).notifier)
                   .appendReply(map),
             ),
           ),

--- a/lib/modules/activity/reply_card.dart
+++ b/lib/modules/activity/reply_card.dart
@@ -86,7 +86,12 @@ class ReplyCard extends StatelessWidget {
                     ],
                     Visibility(
                         visible: reply.user.id != Options().id,
-                        child: _ReplyMentionButton(ref, activityId, reply.user)
+                        child: Row(
+                          children: [
+                            _ReplyMentionButton(ref, activityId, reply.user),
+                            const SizedBox(width: 10),
+                          ],
+                        )
                     ),
                     _ReplyLikeButton(reply),
                   ],
@@ -167,29 +172,24 @@ class _ReplyMentionButtonState extends State<_ReplyMentionButton> {
   Widget build(BuildContext context) {
     return SizedBox(
       height: 40,
-      child: Row(
-        children: [
-          Tooltip(
-            message: 'Reply',
-            child: InkResponse(
-              radius: 10,
-              onTap: () => showSheet(
-                context,
-                CompositionView(
-                  composition: Composition.reply(null, '@${widget.user.name} ', widget.activityId),
-                  onDone: (map) => widget.ref
-                      .read(activityProvider(widget.activityId).notifier)
-                      .appendReply(map),
-                ),
-              ),
-              child: const Icon(
-                Icons.reply,
-                size: Consts.iconSmall,
-              ),
+      child: Tooltip(
+        message: 'Reply',
+        child: InkResponse(
+          radius: 10,
+          onTap: () => showSheet(
+            context,
+            CompositionView(
+              composition: Composition.reply(null, '@${widget.user.name} ', widget.activityId),
+              onDone: (map) => widget.ref
+                  .read(activityProvider(widget.activityId).notifier)
+                  .appendReply(map),
             ),
           ),
-          const SizedBox(width: 10),
-        ],
+          child: const Icon(
+            Icons.reply,
+            size: Consts.iconSmall,
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Alternative implementation for https://github.com/lotusprey/otraku/issues/92 

They say that a picture says more than a thousand words

![Screenshot_20231127_230649](https://github.com/lotusprey/otraku/assets/35780068/0adb5f14-688c-4f35-ae8e-0c1453eeeb3e)

![Screenshot_20231127_231012](https://github.com/lotusprey/otraku/assets/35780068/e7615026-5be3-4b2c-9ab0-2e4a77bf59f7)

The initially suggested `Icons.quickreply_outlined` doesn't fit at all, imo

![Screenshot_20231127_225941](https://github.com/lotusprey/otraku/assets/35780068/607222ce-3e6a-4c3a-be20-1867932e1cce)
