### PR TITLE
Make images respect data saver mode

### DIFF
--- a/lib/common/utils/image_quality.dart
+++ b/lib/common/utils/image_quality.dart
@@ -1,0 +1,20 @@
+import 'package:data_saver/data_saver.dart';
+import 'package:otraku/common/utils/options.dart';
+
+String _imageQuality = Options().imageQuality.value;
+
+String get imageQuality => _imageQuality;
+
+void refreshImageQuality() async {
+  var quality = Options().imageQuality;
+  var ignoreDataSaver = Options().ignoreDataSaverMode;
+
+  if (!ignoreDataSaver) {
+    var dataSaverMode = await const DataSaver().checkMode();
+    if (dataSaverMode == DataSaverMode.enabled) {
+      quality = ImageQuality.Medium;
+    }
+  }
+
+  _imageQuality = quality.value;
+}

--- a/lib/common/utils/options.dart
+++ b/lib/common/utils/options.dart
@@ -2,11 +2,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:otraku/modules/auth/account.dart';
+import 'package:otraku/common/utils/image_quality.dart';
+import 'package:otraku/common/utils/theming.dart';
 import 'package:otraku/modules/calendar/calendar_models.dart';
 import 'package:otraku/modules/discover/discover_models.dart';
 import 'package:otraku/modules/home/home_provider.dart';
 import 'package:otraku/modules/media/media_constants.dart';
-import 'package:otraku/common/utils/theming.dart';
 import 'package:path_provider/path_provider.dart';
 
 /// Current app version.
@@ -26,6 +27,7 @@ enum _OptionKey {
   animeCollectionPreview,
   mangaCollectionPreview,
   airingSortForPreview,
+  ignoreDataSaverMode,
   confirmExit,
   leftHanded,
   analogueClock,
@@ -85,6 +87,7 @@ class Options extends ChangeNotifier {
     this._analogueClock,
     this._feedOnFollowing,
     this._viewerActivitiesInFeed,
+    this._ignoreDataSaverMode,
     this._calendarSeason,
     this._calendarStatus,
     this._discoverItemView,
@@ -183,6 +186,7 @@ class Options extends ChangeNotifier {
       _optionBox.get(_OptionKey.analogueClock.name) ?? false,
       _optionBox.get(_OptionKey.feedOnFollowing.name) ?? false,
       _optionBox.get(_OptionKey.viewerActivitiesInFeed.name) ?? false,
+      _optionBox.get(_OptionKey.ignoreDataSaverMode.name) ?? false,
       calendarSeason,
       calendarStatus,
       discoverItemView,
@@ -246,6 +250,7 @@ class Options extends ChangeNotifier {
   bool _analogueClock;
   bool _feedOnFollowing;
   bool _viewerActivitiesInFeed;
+  bool _ignoreDataSaverMode;
   int _calendarSeason;
   int _calendarStatus;
   int _discoverItemView;
@@ -275,6 +280,7 @@ class Options extends ChangeNotifier {
   bool get analogueClock => _analogueClock;
   bool get feedOnFollowing => _feedOnFollowing;
   bool get viewerActivitiesInFeed => _viewerActivitiesInFeed;
+  bool get ignoreDataSaverMode => _ignoreDataSaverMode;
   int get calendarSeason => _calendarSeason;
   int get calendarStatus => _calendarStatus;
   int get discoverItemView => _discoverItemView;
@@ -366,6 +372,7 @@ class Options extends ChangeNotifier {
   set imageQuality(ImageQuality v) {
     _imageQuality = v;
     _optionBox.put(_OptionKey.imageQuality.name, v.index);
+    refreshImageQuality();
   }
 
   set animeCollectionPreview(bool v) {
@@ -406,6 +413,12 @@ class Options extends ChangeNotifier {
   set viewerActivitiesInFeed(bool v) {
     _viewerActivitiesInFeed = v;
     _optionBox.put(_OptionKey.viewerActivitiesInFeed.name, v);
+  }
+
+  set ignoreDataSaverMode(bool v) {
+    _ignoreDataSaverMode = v;
+    _optionBox.put(_OptionKey.ignoreDataSaverMode.name, v);
+    refreshImageQuality();
   }
 
   set calendarSeason(int v) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,14 +6,16 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:otraku/common/utils/api.dart';
-import 'package:otraku/common/utils/routing.dart';
-import 'package:otraku/modules/home/home_provider.dart';
 import 'package:otraku/common/utils/background_handler.dart';
+import 'package:otraku/common/utils/image_quality.dart';
 import 'package:otraku/common/utils/options.dart';
+import 'package:otraku/common/utils/routing.dart';
 import 'package:otraku/common/utils/theming.dart';
+import 'package:otraku/modules/home/home_provider.dart';
 
 Future<void> main() async {
   await Options.init();
+  refreshImageQuality();
   await Api.init();
   BackgroundHandler.init(_notificationCtrl);
   runApp(const ProviderScope(child: App()));

--- a/lib/modules/activity/activity_models.dart
+++ b/lib/modules/activity/activity_models.dart
@@ -1,6 +1,6 @@
 import 'package:otraku/common/models/paged.dart';
 import 'package:otraku/common/utils/extensions.dart';
-import 'package:otraku/common/utils/options.dart';
+import 'package:otraku/common/utils/image_quality.dart';
 
 class ExpandedActivity {
   ExpandedActivity(this.activity, this.replies);
@@ -187,7 +187,7 @@ class ActivityMedia {
   factory ActivityMedia(Map<String, dynamic> map) => ActivityMedia._(
         id: map['media']['id'],
         title: map['media']['title']['userPreferred'],
-        imageUrl: map['media']['coverImage'][Options().imageQuality.value],
+        imageUrl: map['media']['coverImage'][imageQuality],
         format: StringUtil.tryNoScreamingSnakeCase(map['media']['format']),
         isAnime: map['type'] == 'ANIME_LIST',
       );

--- a/lib/modules/calendar/calendar_models.dart
+++ b/lib/modules/calendar/calendar_models.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:otraku/common/utils/extensions.dart';
-import 'package:otraku/common/utils/options.dart';
+import 'package:otraku/common/utils/image_quality.dart';
 import 'package:otraku/modules/collection/collection_models.dart';
 
 class CalendarItem {
@@ -33,7 +33,7 @@ class CalendarItem {
     return CalendarItem._(
       mediaId: map['mediaId'],
       title: map['media']['title']['userPreferred'],
-      cover: map['media']['coverImage'][Options().imageQuality.value],
+      cover: map['media']['coverImage'][imageQuality],
       episode: map['episode'],
       airingAt: DateTimeUtil.fromSecondsSinceEpoch(map['airingAt']),
       entryStatus: EntryStatus.formatText(

--- a/lib/modules/character/character_providers.dart
+++ b/lib/modules/character/character_providers.dart
@@ -1,12 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:otraku/common/utils/extensions.dart';
-import 'package:otraku/modules/character/character_models.dart';
-import 'package:otraku/modules/discover/discover_models.dart';
+import 'package:otraku/common/models/paged.dart';
 import 'package:otraku/common/models/relation.dart';
 import 'package:otraku/common/utils/api.dart';
+import 'package:otraku/common/utils/extensions.dart';
 import 'package:otraku/common/utils/graphql.dart';
-import 'package:otraku/common/models/paged.dart';
-import 'package:otraku/common/utils/options.dart';
+import 'package:otraku/common/utils/image_quality.dart';
+import 'package:otraku/modules/character/character_models.dart';
+import 'package:otraku/modules/discover/discover_models.dart';
 
 /// Favorite/Unfavorite character. Returns `true` if successful.
 Future<bool> toggleFavoriteCharacter(int characterId) async {
@@ -91,7 +91,7 @@ class CharacterMediaNotifier extends StateNotifier<CharacterMedia> {
           items.add(Relation(
             id: a['node']['id'],
             title: a['node']['title']['userPreferred'],
-            imageUrl: a['node']['coverImage'][Options().imageQuality.value],
+            imageUrl: a['node']['coverImage'][imageQuality],
             subtitle: StringUtil.tryNoScreamingSnakeCase(a['characterRole']),
             type: DiscoverType.Anime,
           ));
@@ -144,7 +144,7 @@ class CharacterMediaNotifier extends StateNotifier<CharacterMedia> {
           items.add(Relation(
             id: m['node']['id'],
             title: m['node']['title']['userPreferred'],
-            imageUrl: m['node']['coverImage'][Options().imageQuality.value],
+            imageUrl: m['node']['coverImage'][imageQuality],
             subtitle: StringUtil.tryNoScreamingSnakeCase(m['characterRole']),
             type: DiscoverType.Manga,
           ));

--- a/lib/modules/collection/collection_models.dart
+++ b/lib/modules/collection/collection_models.dart
@@ -1,7 +1,7 @@
 import 'package:otraku/common/utils/extensions.dart';
+import 'package:otraku/common/utils/image_quality.dart';
 import 'package:otraku/modules/filter/filter_models.dart';
 import 'package:otraku/modules/media/media_constants.dart';
-import 'package:otraku/common/utils/options.dart';
 
 typedef CollectionTag = ({int userId, bool ofAnime});
 
@@ -348,7 +348,7 @@ class Entry {
     return Entry._(
       mediaId: map['media']['id'],
       titles: titles,
-      imageUrl: map['media']['coverImage'][Options().imageQuality.value],
+      imageUrl: map['media']['coverImage'][imageQuality],
       format: map['media']['format'],
       status: map['media']['status'],
       entryStatus: EntryStatus.values.byName(map['status']),

--- a/lib/modules/discover/discover_models.dart
+++ b/lib/modules/discover/discover_models.dart
@@ -1,7 +1,7 @@
 import 'package:otraku/common/models/paged.dart';
 import 'package:otraku/common/models/tile_item.dart';
 import 'package:otraku/common/utils/extensions.dart';
-import 'package:otraku/common/utils/options.dart';
+import 'package:otraku/common/utils/image_quality.dart';
 import 'package:otraku/modules/collection/collection_models.dart';
 import 'package:otraku/modules/filter/filter_models.dart';
 import 'package:otraku/modules/review/review_models.dart';
@@ -121,7 +121,7 @@ class DiscoverMediaItem extends TileItem {
         id: map['id'],
         type: map['type'] == 'ANIME' ? DiscoverType.Anime : DiscoverType.Manga,
         title: map['title']['userPreferred'],
-        imageUrl: map['coverImage'][Options().imageQuality.value],
+        imageUrl: map['coverImage'][imageQuality],
         format: StringUtil.tryNoScreamingSnakeCase(map['format']),
         releaseStatus: StringUtil.tryNoScreamingSnakeCase(map['status']),
         listStatus: EntryStatus.formatText(

--- a/lib/modules/media/media_models.dart
+++ b/lib/modules/media/media_models.dart
@@ -1,21 +1,21 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:otraku/common/utils/extensions.dart';
-import 'package:otraku/modules/collection/collection_models.dart';
 import 'package:otraku/common/models/paged.dart';
 import 'package:otraku/common/models/relation.dart';
 import 'package:otraku/common/models/tile_item.dart';
+import 'package:otraku/common/utils/extensions.dart';
+import 'package:otraku/common/utils/image_quality.dart';
+import 'package:otraku/modules/collection/collection_models.dart';
 import 'package:otraku/modules/discover/discover_models.dart';
 import 'package:otraku/modules/edit/edit_model.dart';
 import 'package:otraku/modules/media/media_constants.dart';
 import 'package:otraku/modules/tag/tag_models.dart';
-import 'package:otraku/common/utils/options.dart';
 
 TileItem mediaItem(Map<String, dynamic> map) => TileItem(
       id: map['id'],
       type: DiscoverType.Anime,
       title: map['title']['userPreferred'],
-      imageUrl: map['coverImage'][Options().imageQuality.value],
+      imageUrl: map['coverImage'][imageQuality],
     );
 
 class Media {
@@ -121,7 +121,7 @@ class RelatedMedia {
   factory RelatedMedia(Map<String, dynamic> map) => RelatedMedia._(
         id: map['node']['id'],
         title: map['node']['title']['userPreferred'],
-        imageUrl: map['node']['coverImage'][Options().imageQuality.value],
+        imageUrl: map['node']['coverImage'][imageQuality],
         relationType: StringUtil.tryNoScreamingSnakeCase(map['relationType']),
         format: StringUtil.tryNoScreamingSnakeCase(map['node']['format']),
         status: StringUtil.tryNoScreamingSnakeCase(map['node']['status']),
@@ -223,8 +223,7 @@ class Recommendation {
       userRating: userRating,
       title: map['mediaRecommendation']['title']['userPreferred'],
       type: map['type'] == 'ANIME' ? DiscoverType.Anime : DiscoverType.Manga,
-      imageUrl: map['mediaRecommendation']['coverImage']
-          [Options().imageQuality.value],
+      imageUrl: map['mediaRecommendation']['coverImage'][imageQuality],
     );
   }
 
@@ -339,7 +338,7 @@ class MediaInfo {
       nativeTitle: map['title']['native'],
       synonyms: List<String>.from(map['synonyms'] ?? [], growable: false),
       description: map['description'] ?? '',
-      cover: map['coverImage'][Options().imageQuality.value],
+      cover: map['coverImage'][imageQuality],
       extraLargeCover: map['coverImage']['extraLarge'],
       banner: map['bannerImage'],
       format: StringUtil.tryNoScreamingSnakeCase(map['format']),

--- a/lib/modules/notification/notification_model.dart
+++ b/lib/modules/notification/notification_model.dart
@@ -1,6 +1,6 @@
 import 'package:otraku/common/utils/extensions.dart';
+import 'package:otraku/common/utils/image_quality.dart';
 import 'package:otraku/modules/discover/discover_models.dart';
-import 'package:otraku/common/utils/options.dart';
 
 enum NotificationFilterType {
   all('All'),
@@ -279,7 +279,7 @@ class SiteNotification {
             type: NotificationType.AIRING,
             headId: map['media']['id'],
             bodyId: map['media']['id'],
-            imageUrl: map['media']['coverImage'][Options().imageQuality.value],
+            imageUrl: map['media']['coverImage'][imageQuality],
             texts: [
               'Episode ',
               map['episode'].toString(),
@@ -301,7 +301,7 @@ class SiteNotification {
             type: NotificationType.RELATED_MEDIA_ADDITION,
             headId: map['media']['id'],
             bodyId: map['media']['id'],
-            imageUrl: map['media']['coverImage'][Options().imageQuality.value],
+            imageUrl: map['media']['coverImage'][imageQuality],
             texts: [
               map['media']['title']['userPreferred'],
               ' was added to the site',
@@ -319,7 +319,7 @@ class SiteNotification {
             id: map['id'],
             type: NotificationType.MEDIA_DATA_CHANGE,
             headId: map['media']['id'],
-            imageUrl: map['media']['coverImage'][Options().imageQuality.value],
+            imageUrl: map['media']['coverImage'][imageQuality],
             details: map['reason'],
             texts: [
               map['media']['title']['userPreferred'],
@@ -344,7 +344,7 @@ class SiteNotification {
             id: map['id'],
             type: NotificationType.MEDIA_MERGE,
             headId: map['media']['id'],
-            imageUrl: map['media']['coverImage'][Options().imageQuality.value],
+            imageUrl: map['media']['coverImage'][imageQuality],
             details: map['reason'],
             texts: [
               '${titles.join(", ")} ${titles.length < 2 ? "was" : "were"} merged into ',

--- a/lib/modules/review/review_models.dart
+++ b/lib/modules/review/review_models.dart
@@ -1,5 +1,5 @@
 import 'package:otraku/common/utils/extensions.dart';
-import 'package:otraku/common/utils/options.dart';
+import 'package:otraku/common/utils/image_quality.dart';
 
 class ReviewItem {
   ReviewItem._({
@@ -55,7 +55,7 @@ class Review {
         userName: map['user']['name'] ?? '',
         userAvatar: map['user']['avatar']['large'],
         mediaTitle: map['media']['title']['userPreferred'] ?? '',
-        mediaCover: map['media']['coverImage'][Options().imageQuality.value],
+        mediaCover: map['media']['coverImage'][imageQuality],
         banner: map['media']['bannerImage'],
         summary: map['summary'] ?? '',
         text: map['body'] ?? '',

--- a/lib/modules/settings/settings_app_tab.dart
+++ b/lib/modules/settings/settings_app_tab.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:otraku/common/widgets/layouts/top_bar.dart';
-import 'package:otraku/modules/discover/discover_models.dart';
-import 'package:otraku/modules/filter/chip_selector.dart';
 import 'package:otraku/common/utils/consts.dart';
-import 'package:otraku/modules/home/home_provider.dart';
-import 'package:otraku/modules/media/media_constants.dart';
 import 'package:otraku/common/utils/options.dart';
 import 'package:otraku/common/widgets/fields/checkbox_field.dart';
 import 'package:otraku/common/widgets/fields/drop_down_field.dart';
 import 'package:otraku/common/widgets/grids/sliver_grid_delegates.dart';
+import 'package:otraku/common/widgets/layouts/top_bar.dart';
 import 'package:otraku/common/widgets/loaders/loaders.dart';
-import 'package:otraku/modules/settings/theme_preview.dart';
 import 'package:otraku/common/widgets/overlays/sheets.dart';
+import 'package:otraku/modules/discover/discover_models.dart';
+import 'package:otraku/modules/filter/chip_selector.dart';
+import 'package:otraku/modules/home/home_provider.dart';
+import 'package:otraku/modules/media/media_constants.dart';
+import 'package:otraku/modules/settings/theme_preview.dart';
 
 class SettingsAppTab extends StatelessWidget {
   const SettingsAppTab(this.scrollCtrl);
@@ -210,6 +210,11 @@ class SettingsAppTab extends StatelessWidget {
             height: Consts.tapTargetSize,
           ),
           delegate: SliverChildListDelegate.fixed([
+            CheckBoxField(
+              title: 'Ignore Data Saving Mode',
+              initial: Options().ignoreDataSaverMode,
+              onChanged: (val) => Options().ignoreDataSaverMode = val,
+            ),
             CheckBoxField(
               title: 'Left-Handed Mode',
               initial: Options().leftHanded,

--- a/lib/modules/staff/staff_providers.dart
+++ b/lib/modules/staff/staff_providers.dart
@@ -1,12 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:otraku/common/utils/extensions.dart';
-import 'package:otraku/modules/discover/discover_models.dart';
-import 'package:otraku/common/models/relation.dart';
-import 'package:otraku/modules/staff/staff_models.dart';
-import 'package:otraku/common/utils/api.dart';
-import 'package:otraku/common/utils/graphql.dart';
 import 'package:otraku/common/models/paged.dart';
-import 'package:otraku/common/utils/options.dart';
+import 'package:otraku/common/models/relation.dart';
+import 'package:otraku/common/utils/api.dart';
+import 'package:otraku/common/utils/extensions.dart';
+import 'package:otraku/common/utils/graphql.dart';
+import 'package:otraku/common/utils/image_quality.dart';
+import 'package:otraku/modules/discover/discover_models.dart';
+import 'package:otraku/modules/staff/staff_models.dart';
 
 /// Favorite/Unfavorite staff. Returns `true` if successful.
 Future<bool> toggleFavoriteStaff(int staffId) async {
@@ -87,7 +87,7 @@ class StaffRelationNotifier extends StateNotifier<StaffRelations> {
           final media = Relation(
             id: m['node']['id'],
             title: m['node']['title']['userPreferred'],
-            imageUrl: m['node']['coverImage'][Options().imageQuality.value],
+            imageUrl: m['node']['coverImage'][imageQuality],
             subtitle: StringUtil.tryNoScreamingSnakeCase(m['node']['format']),
             type: m['node']['type'] == 'ANIME'
                 ? DiscoverType.Anime
@@ -130,7 +130,7 @@ class StaffRelationNotifier extends StateNotifier<StaffRelations> {
           items.add(Relation(
             id: s['node']['id'],
             title: s['node']['title']['userPreferred'],
-            imageUrl: s['node']['coverImage'][Options().imageQuality.value],
+            imageUrl: s['node']['coverImage'][imageQuality],
             subtitle: s['staffRole'],
             type: s['node']['type'] == 'ANIME'
                 ? DiscoverType.Anime

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  data_saver:
+    dependency: "direct main"
+    description:
+      name: data_saver
+      sha256: "124c2b36e52c7bd82b0c8f4f1a77ae01bf06cf7ac18441a1221a0f6c2a083ddc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,9 @@ dependencies:
   # An addition to the material icons.
   ionicons: ^0.2.1
 
+  # For checking the data saving mode of the device
+  data_saver: ^0.0.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
The image quality now also depends on the data saver mode the user configured in the operating system. This behavior can be bypassed via a new config option (might be unnecessary). Since Flutter doesn't allow you to access this setting natively, I had to include a new library whose size should (hopefully?) be negligible. Whether the connection is metered is currently not checked, and would most likely require yet another library. Changes to the device's native data saver setting are ignored unless the app is restarted or one of the relevant config options changes.

The new file `lib/common/utils/image_quality.dart` currently does not contain a class, but it [might be preferable](https://haste.devcord.club/vayoqezefu.cs). I can change it if that's the case.

The motivation for this change is the fact that users who are regularly on very limited connections might not want to change this kind of behavior for each app manually. Moreover, starting the app to update the quality in the settings already loads a considerable number of images in the home feed, which might cost them precious data volume or even money.

On Android, users can manually whitelist apps. If Otraku has been whitelisted, the app will display images normally. Only if data saver mode is enabled and the app hasn't been whitelisted, the images' resolution is lowered to medium. Whitelisted apps are supposed to still limit their data usage, so setting the quality to high at most might be worth considering.