### PR TITLE
Open AL links as inAppBrowserView and make the snackbar floating

### DIFF
--- a/lib/extension/snack_bar_extension.dart
+++ b/lib/extension/snack_bar_extension.dart
@@ -23,7 +23,9 @@ extension SnackBarExtension on SnackBar {
     try {
       final ok = await launchUrl(
         Uri.parse(link),
-        mode: LaunchMode.externalApplication,
+        mode: link.startsWith("https://anilist.co")
+            ? LaunchMode.externalApplication
+            : LaunchMode.inAppBrowserView,
       );
 
       if (ok) return true;

--- a/lib/extension/snack_bar_extension.dart
+++ b/lib/extension/snack_bar_extension.dart
@@ -25,8 +25,8 @@ extension SnackBarExtension on SnackBar {
       final ok = await launchUrl(
         Uri.parse(link),
         mode: link.startsWith("https://anilist.co")
-            ? LaunchMode.externalApplication
-            : LaunchMode.inAppBrowserView,
+            ? LaunchMode.inAppBrowserView
+            : LaunchMode.externalApplication,
       );
 
       if (ok) return true;

--- a/lib/extension/snack_bar_extension.dart
+++ b/lib/extension/snack_bar_extension.dart
@@ -9,6 +9,7 @@ extension SnackBarExtension on SnackBar {
   ) {
     return ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text(text),
+      behavior: SnackBarBehavior.floating,
     ));
   }
 


### PR DESCRIPTION
Changes **every** link starting with `https://anilist.co` to open in the in-app browser. So please check if auth and etc are working. However, I tried the authentication/redirection process on two devices and they seem to work fine. (Xiaomi and Samsung)